### PR TITLE
Travis cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: rust
+cache: cargo
+dist: trusty
 sudo: false
+rust:
+  - stable
 
 matrix:
   include:
@@ -7,17 +11,11 @@ matrix:
     - rust: beta
     - rust: nightly
 
-install:
-  - |
-      pip install 'travis-cargo<0.2' --user &&
-      export PATH=$HOME/.local/bin:$PATH
-
 script:
   - |
-      travis-cargo build &&
-      travis-cargo build -- --release &&
-      travis-cargo test &&
-      travis-cargo test -- --release &&
-      travis-cargo bench &&
-      travis-cargo --only stable doc
-
+      cargo build &&
+      cargo build -- --release &&
+      cargo test &&
+      cargo test -- --release &&
+      cargo bench &&
+      cargo --only stable doc

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/apoelstra/rust-secp256k1.png?branch=master)](https://travis-ci.org/apoelstra/rust-secp256k1)
+[![Build Status](https://travis-ci.org/mimblewimble/rust-secp256k1-zkp.png?branch=master)](https://travis-ci.org/mimblewimble/rust-secp256k1-zkp)
 
 ### rust-secp256k1
 
@@ -12,4 +12,3 @@ a C library by Peter Wuille for producing ECDSA signatures using the SECG curve
 * makes no allocations (except in unit tests) for efficiency and use in freestanding implementations
 
 [Full documentation](https://www.wpsoftware.net/rustdoc/secp256k1/)
-


### PR DESCRIPTION
* point travis badge at `mimblewimble/rust-secp256k1-zkp`
* we don't need `travis-cargo` any more
* `cache: cargo`
