### PR TITLE
Message in range proof - rewind to recover value and message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ script:
       cargo test &&
       cargo test --release &&
       cargo bench &&
-      cargo --only stable doc
+      cargo doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ matrix:
 script:
   - |
       cargo build &&
-      cargo build -- --release &&
+      cargo build --release &&
       cargo test &&
-      cargo test -- --release &&
+      cargo test --release &&
       cargo bench &&
       cargo --only stable doc

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -267,6 +267,7 @@ pub struct ProofRange {
 }
 
 /// Information about a valid proof after rewinding it.
+#[derive(Debug)]
 pub struct ProofInfo {
 	/// Whether the proof is valid or not
 	pub success: bool,


### PR DESCRIPTION
The PR does the following - 

1) exposes msg as a param to `range_proof`
1) uses the `secret_key` as the nonce in `range_proof`
1) allows the same secret key to be passed in as the nonce in `rewind_range_proof`
1) introduces a new `MessageProof` struct so we can conveniently interact with the msg itself
1) also fixes running the tests in travis (cargo command was broken from earlier)

This lets us rewind a range_proof to recover both the original _value_ and original _message_ from the proof.

If someone with more knowledge of the underlying secp lib could confirm (2) is safe to do that would be much appreciated.

This resolves issue #7.

__Note:__ this is a breaking change to the secp api and will break Grin (the msg param is new).
The corresponding PR on the grin side is here - ignopeverell/grin#155.

What's the process here - do we get away with merging these 2 related PRs together - or do we want to manage backward compatibility across these 2 repos somehow?
One option may be to tag `rust-secp256k1-zkp` and specify the tag in Cargo.toml in Grin prior to merging this?


