### PR TITLE
minor fix: clean some boring build warnings

### DIFF
--- a/src/aggsig.rs
+++ b/src/aggsig.rs
@@ -380,7 +380,7 @@ mod tests {
             let secnonce_2 = export_secnonce_single(&secp).unwrap();
 
             // Calculate public nonces
-            let _pubnonce_1 = PublicKey::from_secret_key(&secp, &secnonce_1).unwrap();
+            let _ = PublicKey::from_secret_key(&secp, &secnonce_1).unwrap();
             let pubnonce_2 = PublicKey::from_secret_key(&secp, &secnonce_2).unwrap();
 
             // And get the total

--- a/src/aggsig.rs
+++ b/src/aggsig.rs
@@ -285,7 +285,6 @@ impl Drop for AggSigContext {
 mod tests {
     use ContextFlag;
     use {Message, AggSigPartialSignature};
-    use ffi;
     use super::{AggSigContext, Secp256k1, sign_single, verify_single, export_secnonce_single, add_signatures_single};
     use rand::{Rng, thread_rng};
     use key::{SecretKey, PublicKey};
@@ -381,7 +380,7 @@ mod tests {
             let secnonce_2 = export_secnonce_single(&secp).unwrap();
 
             // Calculate public nonces
-            let pubnonce_1 = PublicKey::from_secret_key(&secp, &secnonce_1).unwrap();
+            let _pubnonce_1 = PublicKey::from_secret_key(&secp, &secnonce_1).unwrap();
             let pubnonce_2 = PublicKey::from_secret_key(&secp, &secnonce_2).unwrap();
 
             // And get the total

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -27,11 +27,10 @@ use Secp256k1;
 
 use constants;
 use ffi;
-use key::{self, SecretKey, PublicKey};
+use key::{self, SecretKey};
 use super::{Message, Signature};
 use rand::{Rng, OsRng};
 use serde::{ser, de};
-use std::ptr;
 
 const MAX_WIDTH:usize = 1 << 20;
 


### PR DESCRIPTION
There're several boring warnings, clean them firstly:)

Sometimes I have to do several git cherry-pick from my master branch, so perhaps look like multiple commits.