### PR TITLE
fix: rangeproof_info function only has 7 parameters instead of 10

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -420,10 +420,7 @@ extern "C" {
 		min_value: *mut uint64_t,
 		max_value: *mut uint64_t,
 		proof: *const c_uchar,
-		plen: size_t,
-		extra_commit: *const c_uchar,
-		extra_commit_len: size_t,
-		gen: *const c_uchar
+		plen: size_t
 	) -> c_int;
 
 	pub fn secp256k1_rangeproof_rewind(

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -585,8 +585,6 @@ impl Secp256k1 {
 		let mut min: u64 = 0;
 		let mut max: u64 = 0;
 
-		let extra_commit = [0u8; 33];
-
 		let success = unsafe {
 			ffi::secp256k1_rangeproof_info(
 				self.ctx,
@@ -596,9 +594,6 @@ impl Secp256k1 {
 				&mut max,
 				proof.proof.as_ptr(),
 				proof.plen as size_t,
-				extra_commit.as_ptr(),
-				0 as size_t,
-				constants::GENERATOR_H.as_ptr(),
 			) == 1
 		};
 		ProofInfo {


### PR DESCRIPTION

fix: ffi secp256k1_rangeproof_info() only has 7 parameters instead of 10.