### PR TITLE
removed api secp256k1_switch_commit(), not used anymore

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -358,14 +358,6 @@ extern "C" {
                           scalar: *const c_uchar)
                           -> c_int;
 
-    // Generates a switch commitment: *commit = blind * J
-    // The commitment is 33 bytes, the blinding factor is 32 bytes.
-    pub fn secp256k1_switch_commit(ctx: *const Context,
-                                   commit: *mut c_uchar,
-                                   blind: *const c_uchar,
-                                   gen: *const c_uchar)
-                                   -> c_int;
-
 	// Generates a pedersen commitment: *commit = blind * G + value * G2.
 	// The commitment is 33 bytes, the blinding factor is 32 bytes.
 	pub fn secp256k1_pedersen_commit(

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -297,19 +297,6 @@ impl Secp256k1 {
 		}
 	}
 
-	/// Creates a switch commitment from a blinding factor.
-	pub fn switch_commit(&self,  blind: SecretKey) -> Result<Commitment, Error> {
-
-		if self.caps != ContextFlag::Commit {
-			return Err(Error::IncapableContext);
-		}
-		let mut commit = [0; 33];
-		unsafe {
-			ffi::secp256k1_switch_commit(self.ctx, commit.as_mut_ptr(), blind.as_ptr(), constants::GENERATOR_J.as_ptr());
-		};
-		Ok(Commitment(commit))
-	}
-
 	/// Creates a pedersen commitment from a value and a blinding factor
 	pub fn commit(&self, value: u64, blind: SecretKey) -> Result<Commitment, Error> {
 


### PR DESCRIPTION
removed api `secp256k1_switch_commit()`, doesn't exist anymore in `secp256k1-zkp`, and also not used anymore in this lib.
