### PR TITLE
test: expose the failure of batch verification on 4 proofs and so on

### DIFF
--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -1205,5 +1205,21 @@ mod tests {
 			panic!("Bullet proof multi verify should have error.");
 		}
 
+		//  batching verification on 1-100 elements w/o extra message data
+		println!("7");
+		commits = vec![];
+		proofs = vec![];
+		let mut errs = 0;
+		for i in 1..100 {
+			print!("\r\r\r{}", i);
+			commits.push(secp.commit(value+i as u64, blinding).unwrap());
+			proofs.push(secp.bullet_proof(value+i as u64, blinding, blinding, None));
+			let proof_range = secp.verify_bullet_proof_multi(commits.clone(), proofs.clone(), None);//.unwrap();
+			if proof_range.is_err() {
+				println!(" proofs batch verify failed");
+				errs += 1;
+			}
+		}
+		assert_eq!(errs, 0);
 	}
 }


### PR DESCRIPTION
Enhance the test to expose the failure of batch verification on range proofs.

So far, very confusing problem:

- Mac OS OK, no this problem
- On Linux, always fail for 4/17/18/19/20 range proofs verification, no other failure up to 1000 range proofs
- If rollback https://github.com/mimblewimble/rust-secp256k1-zkp/commit/c61bc85011ee48dce393e6db0907be4637291539 (which is for`change proof validate to be non-consensus breaking`),  then on Linux, always fail for 4 range proofs verification, only fail for 4!


Investigation still on going. 

And this PR is just to enhance the test to expose the problem, and surely it will cause travis-ci fail on Linux test, but it's the purpose.

