### PR TITLE
aggsig api verify_single() security enhancement

### DIFF
--- a/src/aggsig.rs
+++ b/src/aggsig.rs
@@ -24,6 +24,13 @@ use {Message, Error, Signature, AggSigPartialSignature};
 use key::{SecretKey, PublicKey};
 use std::ptr;
 
+/// The 256 bits 0
+const ZERO_256: [u8; 32] = [0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0];
+
+
 /// Single-Signer (plain old Schnorr, sans-multisig) export nonce
 /// Returns: Ok(SecretKey) on success
 /// In: 
@@ -111,7 +118,7 @@ pub fn verify_single(secp: &Secp256k1, sig:&Signature, msg:&Message, pubnonce:Op
         false => 0,
     };
 
-    if (sig.0).0.ends_with(&[0u8; 32]) || (pubkey.0).0.starts_with(&[0u8; 32]) {
+    if (sig.0).0.ends_with(&ZERO_256) || (pubkey.0).0.starts_with(&ZERO_256) {
         return false;
     }
 

--- a/src/aggsig.rs
+++ b/src/aggsig.rs
@@ -111,6 +111,10 @@ pub fn verify_single(secp: &Secp256k1, sig:&Signature, msg:&Message, pubnonce:Op
         false => 0,
     };
 
+    if (sig.0).0.ends_with(&[0u8; 32]) || (pubkey.0).0.starts_with(&[0u8; 32]) {
+        return false;
+    }
+
     let retval = unsafe {
         ffi::secp256k1_aggsig_verify_single(secp.ctx,
                                             sig.as_ptr(),
@@ -276,7 +280,8 @@ impl Drop for AggSigContext {
 #[cfg(test)]
 mod tests {
     use ContextFlag;
-    use {Message, AggSigPartialSignature};
+    use ffi;
+    use {Message, Signature, AggSigPartialSignature};
     use super::{AggSigContext, Secp256k1, sign_single, verify_single, export_secnonce_single, add_signatures_single};
     use rand::{Rng, thread_rng};
     use key::{SecretKey, PublicKey};
@@ -356,6 +361,65 @@ mod tests {
         println!("Verifying aggsig single: {:?}, msg: {:?}, pk:{:?}", sig, msg, pk);
         let result = verify_single(&secp, &sig, &msg, None, &pk, false);
         println!("Signature verification single (wrong message): {}", result);
+        assert!(result==false);
+    }
+
+    #[test]
+    fn test_aggsig_fuzz() {
+        let secp = Secp256k1::with_caps(ContextFlag::Full);
+        let (sk, pk) = secp.generate_keypair(&mut thread_rng()).unwrap();
+
+        println!("Performing aggsig single context with seckey, pubkey: {:?},{:?}", sk, pk);
+
+        let mut msg = [0u8; 32];
+        thread_rng().fill_bytes(&mut msg);
+        let msg = Message::from_slice(&msg).unwrap();
+        let sig=sign_single(&secp, &msg, &sk, None, None, None).unwrap();
+
+        // force sig[32..] as 0 to simulate Fuzz test
+        let corrupted = &mut [0u8; 64];
+        let mut i = 0;
+        for elem in corrupted[..32].iter_mut() {
+            *elem = sig.0[i];
+            i += 1;
+        }
+        let corrupted_sig: Signature = Signature{0:ffi::Signature(*corrupted)};
+        println!("Verifying aggsig single: {:?}, msg: {:?}, pk:{:?}", corrupted_sig, msg, pk);
+        let result = verify_single(&secp, &corrupted_sig, &msg, None, &pk, false);
+        println!("Signature verification single (correct): {}", result);
+        assert!(result==false);
+
+        // force sig[0..32] as 0 to simulate Fuzz test
+        let corrupted = &mut [0u8; 64];
+        let mut i = 32;
+        for elem in corrupted[32..].iter_mut() {
+            *elem = sig.0[i];
+            i += 1;
+        }
+        let corrupted_sig: Signature = Signature{0:ffi::Signature(*corrupted)};
+        println!("Verifying aggsig single: {:?}, msg: {:?}, pk:{:?}", corrupted_sig, msg, pk);
+        let result = verify_single(&secp, &corrupted_sig, &msg, None, &pk, false);
+        println!("Signature verification single (correct): {}", result);
+        assert!(result==false);
+
+        // force pk as 0 to simulate Fuzz test
+        let zero_pk = PublicKey::new();
+        println!("Verifying aggsig single: {:?}, msg: {:?}, pk:{:?}", sig, msg, zero_pk);
+        let result = verify_single(&secp, &sig, &msg, None, &zero_pk, false);
+        println!("Signature verification single (correct): {}", result);
+        assert!(result==false);
+
+        // force pk[0..32] as 0 to simulate Fuzz test
+        let corrupted = &mut [0u8; 64];
+        let mut i = 32;
+        for elem in corrupted[32..].iter_mut() {
+            *elem = pk.0[i];
+            i += 1;
+        }
+        let corrupted_pk: PublicKey = PublicKey{0:ffi::PublicKey(*corrupted)};
+        println!("Verifying aggsig single: {:?}, msg: {:?}, pk:{:?}", sig, msg, corrupted_pk);
+        let result = verify_single(&secp, &sig, &msg, None, &corrupted_pk, false);
+        println!("Signature verification single (correct): {}", result);
         assert!(result==false);
     }
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -74,7 +74,7 @@ impl_raw_debug!(Generator);
 
 /// Library-internal representation of a Secp256k1 public key
 #[repr(C)]
-pub struct PublicKey([c_uchar; 64]);
+pub struct PublicKey(pub [c_uchar; 64]);
 impl_array_newtype!(PublicKey, c_uchar, 64);
 impl_raw_debug!(PublicKey);
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -52,7 +52,7 @@ pub const ONE_KEY: SecretKey = SecretKey([0, 0, 0, 0, 0, 0, 0, 0,
 
 /// A Secp256k1 public key, used for verification of signatures
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
-pub struct PublicKey(ffi::PublicKey);
+pub struct PublicKey(pub ffi::PublicKey);
 
 
 fn random_32_bytes<R: Rng>(rng: &mut R) -> [u8; 32] {


### PR DESCRIPTION
Fix for https://github.com/mimblewimble/grin/issues/1356.

`verify_single()` security enhancement, for the case of value 0 as as public key.

And add a test case `test_aggsig_fuzz`. The test output:

```
$ cargo test --release test_aggsig_fuzz -- --nocapture

running 1 test
Performing aggsig single context with seckey, pubkey: SecretKey(37a7157bc614991e8d9b098010849bb8ad45086c2287f474a55865c56580c0d4),PublicKey(588265989752a87a4f7a35c2257fe4f779d7ddf351825271f5513311ac21c70cecb2f396882b43c2f78e00fc70ceb1654775f24ee0365a08978f12375ef81b67)
Verifying aggsig single: Signature(8b1a8df756f12d2900d34ec56ceaaa39cbd1ddeaead238d9e60be10b9053b0790000000000000000000000000000000000000000000000000000000000000000), msg: Message(cae4239ebe56a791b207302882bf6047d5fc49c277ae9a96938fa3f6e1036516), pk:PublicKey(588265989752a87a4f7a35c2257fe4f779d7ddf351825271f5513311ac21c70cecb2f396882b43c2f78e00fc70ceb1654775f24ee0365a08978f12375ef81b67)
Signature verification single (correct): false
Verifying aggsig single: Signature(000000000000000000000000000000000000000000000000000000000000000043e63e417bddbdfc91da3f27b6b7995e15335f79df94b5982c5b765b2b991c9c), msg: Message(cae4239ebe56a791b207302882bf6047d5fc49c277ae9a96938fa3f6e1036516), pk:PublicKey(588265989752a87a4f7a35c2257fe4f779d7ddf351825271f5513311ac21c70cecb2f396882b43c2f78e00fc70ceb1654775f24ee0365a08978f12375ef81b67)
Signature verification single (correct): false
Verifying aggsig single: Signature(8b1a8df756f12d2900d34ec56ceaaa39cbd1ddeaead238d9e60be10b9053b07943e63e417bddbdfc91da3f27b6b7995e15335f79df94b5982c5b765b2b991c9c), msg: Message(cae4239ebe56a791b207302882bf6047d5fc49c277ae9a96938fa3f6e1036516), pk:PublicKey(00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000)
Signature verification single (correct): false
Verifying aggsig single: Signature(8b1a8df756f12d2900d34ec56ceaaa39cbd1ddeaead238d9e60be10b9053b07943e63e417bddbdfc91da3f27b6b7995e15335f79df94b5982c5b765b2b991c9c), msg: Message(cae4239ebe56a791b207302882bf6047d5fc49c277ae9a96938fa3f6e1036516), pk:PublicKey(0000000000000000000000000000000000000000000000000000000000000000ecb2f396882b43c2f78e00fc70ceb1654775f24ee0365a08978f12375ef81b67)
Signature verification single (correct): false
test aggsig::tests::test_aggsig_fuzz ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 48 filtered out
```
