### PR TITLE
refactor: one missed change on rand refactor

### DIFF
--- a/src/aggsig.rs
+++ b/src/aggsig.rs
@@ -19,7 +19,7 @@
 
 use Secp256k1;
 use ffi;
-use rand::{Rng, prelude::thread_rng};
+use rand::{Rng, thread_rng};
 use {Message, Error, Signature, AggSigPartialSignature};
 use key::{SecretKey, PublicKey};
 use std::ptr;
@@ -316,7 +316,7 @@ mod tests {
     use ffi;
     use {Message, Signature, AggSigPartialSignature};
     use super::{AggSigContext, Secp256k1, sign_single, verify_single, export_secnonce_single, add_signatures_single};
-    use rand::{Rng, prelude::thread_rng};
+    use rand::{Rng, thread_rng};
     use key::{SecretKey, PublicKey};
 
     #[test]

--- a/src/key.rs
+++ b/src/key.rs
@@ -57,7 +57,7 @@ pub struct PublicKey(pub ffi::PublicKey);
 
 fn random_32_bytes<R: Rng>(rng: &mut R) -> [u8; 32] {
     let mut ret = [0u8; 32];
-    rng.fill_bytes(&mut ret);
+    rng.fill(&mut ret);
     ret
 }
 
@@ -374,7 +374,7 @@ mod test {
     use super::{PublicKey, SecretKey};
     use super::super::constants;
 
-    use rand::{Error, RngCore, prelude::thread_rng};
+    use rand::{Error, RngCore, thread_rng};
     use self::rand_core::impls;
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -692,7 +692,7 @@ impl Secp256k1 {
 
 #[cfg(test)]
 mod tests {
-    use rand::{Rng, prelude::thread_rng};
+    use rand::{Rng, thread_rng};
     use serialize::hex::FromHex;
     use key::{SecretKey, PublicKey};
     use super::constants;

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -30,7 +30,7 @@ use constants;
 use ffi;
 use key::{self, SecretKey};
 use super::{Message, Signature};
-use rand::{Rng, prelude::thread_rng};
+use rand::{Rng, thread_rng};
 use serde::{ser, de};
 
 const MAX_WIDTH:usize = 1 << 20;
@@ -889,7 +889,7 @@ mod tests {
     use ContextFlag;
     use key::{ONE_KEY, ZERO_KEY, SecretKey};
 
-    use rand::{Rng, prelude::thread_rng};
+    use rand::{Rng, thread_rng};
 
     use pedersen::tests::chrono::prelude::*;
 


### PR DESCRIPTION
- one missed `rng.fill_bytes()` when refactoring rand
- remove unnecessary `prelude::`