### PR TITLE
refactor: replace most of try with ?

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -261,7 +261,7 @@ impl Decodable for PublicKey {
                     use std::mem;
                     let mut ret: [u8; constants::UNCOMPRESSED_PUBLIC_KEY_SIZE] = mem::uninitialized();
                     for i in 0..len {
-                        ret[i] = try!(d.read_seq_elt(i, |d| Decodable::decode(d)));
+                        ret[i] = d.read_seq_elt(i, |d| Decodable::decode(d))?;
                     }
                     PublicKey::from_slice(&s, &ret).map_err(|_| d.error("invalid public key"))
                 }
@@ -270,7 +270,7 @@ impl Decodable for PublicKey {
                     use std::mem;
                     let mut ret: [u8; constants::COMPRESSED_PUBLIC_KEY_SIZE] = mem::uninitialized();
                     for i in 0..len {
-                        ret[i] = try!(d.read_seq_elt(i, |d| Decodable::decode(d)));
+                        ret[i] = d.read_seq_elt(i, |d| Decodable::decode(d))?;
                     }
                     PublicKey::from_slice(&s, &ret).map_err(|_| d.error("invalid public key"))
                 }
@@ -321,14 +321,14 @@ impl<'de> Deserialize<'de> for PublicKey {
 
                     let mut read_len = 0;
                     while read_len < constants::UNCOMPRESSED_PUBLIC_KEY_SIZE {
-                        let read_ch = match try!(a.next_element()) {
+                        let read_ch = match a.next_element()? {
                             Some(c) => c,
                             None => break
                         };
                         ret[read_len] = read_ch;
                         read_len += 1;
                     }
-                    let one_after_last : Option<u8> = try!(a.next_element());
+                    let one_after_last : Option<u8> = a.next_element()?;
                     if one_after_last.is_some() {
                         return Err(de::Error::invalid_length(read_len + 1, &self));
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,12 +260,12 @@ impl<'de> serde::Deserialize<'de> for Signature {
                     let mut ret: [u8; constants::COMPACT_SIGNATURE_SIZE] = mem::uninitialized();
 
                     for i in 0..constants::COMPACT_SIGNATURE_SIZE {
-                        ret[i] = match try!(a.next_element()) {
+                        ret[i] = match a.next_element()? {
                             Some(c) => c,
                             None => return Err(::serde::de::Error::invalid_length(i, &self))
                         };
                     }
-                    let one_after_last : Option<u8> = try!(a.next_element());
+                    let one_after_last : Option<u8> = a.next_element()?;
                     if one_after_last.is_some() {
                         return Err(serde::de::Error::invalid_length(constants::COMPACT_SIGNATURE_SIZE + 1, &self));
                     }
@@ -607,7 +607,7 @@ impl Secp256k1 {
     pub fn generate_keypair<R: Rng>(&self, rng: &mut R)
                                    -> Result<(key::SecretKey, key::PublicKey), Error> {
         let sk = key::SecretKey::new(self, rng);
-        let pk = try!(key::PublicKey::from_secret_key(self, &sk));
+        let pk = key::PublicKey::from_secret_key(self, &sk)?;
         Ok((sk, pk))
     }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -143,7 +143,7 @@ macro_rules! impl_array_newtype {
                             use std::mem;
                             let mut ret: [$ty; $len] = mem::uninitialized();
                             for i in 0..len {
-                                ret[i] = try!(d.read_seq_elt(i, |d| Decodable::decode(d)));
+                                ret[i] = d.read_seq_elt(i, |d| Decodable::decode(d))?;
                             }
                             Ok($thing(ret))
                         }
@@ -180,12 +180,12 @@ macro_rules! impl_array_newtype {
                             use std::mem;
                             let mut ret: [$ty; $len] = mem::uninitialized();
                             for i in 0..$len {
-                                ret[i] = match try!(a.next_element()) {
+                                ret[i] = match a.next_element()? {
                                     Some(c) => c,
                                     None => return Err(::serde::de::Error::invalid_length(i, &self))
                                 };
                             }
-                            let one_after_last : Option<u8> = try!(a.next_element());
+                            let one_after_last : Option<u8> = a.next_element()?;
                             if one_after_last.is_some() {
                                 return Err(::serde::de::Error::invalid_length($len + 1, &self));
                             }

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -252,9 +252,9 @@ impl ::std::cmp::Eq for ProofMessage {}
 
 impl ::std::fmt::Debug for ProofMessage {
 	fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-		try!(write!(f, "{}(", stringify!(ProofMessage)));
+		write!(f, "{}(", stringify!(ProofMessage))?;
 		for i in self.0.iter().cloned() {
-			try!(write!(f, "{:02x}", i));
+			write!(f, "{:02x}", i)?;
 		}
 		write!(f, ")")
 	}
@@ -296,9 +296,9 @@ pub struct ProofInfo {
 
 impl ::std::fmt::Debug for RangeProof {
 	fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-		try!(write!(f, "{}(", stringify!(RangeProof)));
+		write!(f, "{}(", stringify!(RangeProof))?;
 		for i in self.proof[..self.plen].iter().cloned() {
-			try!(write!(f, "{:02x}", i));
+			write!(f, "{:02x}", i)?;
 		}
 		write!(f, ")[{}]", self.plen)
 	}


### PR DESCRIPTION
minor improve on code readability.

Replace all `try!` with `?`, but leaving 3 `try!` because upstream also having it, for future merging convenience. 

All removed `try!` doesn't come from upstream.