### PR TITLE
stop depending on intrinsics

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -61,7 +61,7 @@ macro_rules! impl_array_newtype {
             #[inline]
             fn clone(&self) -> $thing {
                 unsafe {
-                    use std::intrinsics::copy_nonoverlapping;
+                    use std::ptr::copy_nonoverlapping;
                     use std::mem;
                     let mut ret: $thing = mem::uninitialized();
                     copy_nonoverlapping(self.as_ptr(),

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -126,7 +126,7 @@ impl Clone for RangeProof {
 	#[inline]
 	fn clone(&self) -> RangeProof {
 		unsafe {
-			use std::intrinsics::copy_nonoverlapping;
+			use std::ptr::copy_nonoverlapping;
 			use std::mem;
 			let mut ret: [u8; constants::MAX_PROOF_SIZE] = mem::uninitialized();
 			copy_nonoverlapping(


### PR DESCRIPTION
The interface, though marked stable, is actually not.
See https://github.com/rust-lang/rust/pull/57997.