### PR TITLE
derive Serialize and Deserialize for error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ clippy = {version = "0.0", optional = true}
 rand = "0.5"
 libc = "0.2"
 rustc-serialize = "0.3"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -445,7 +445,7 @@ impl From<[u8; constants::MESSAGE_SIZE]> for Message {
 }
 
 /// An ECDSA error
-#[derive(Copy, PartialEq, Eq, Clone, Debug)]
+#[derive(Copy, PartialEq, Eq, Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub enum Error {
     /// A `Secp256k1` was used for an operation, but it was not created to
     /// support this (so necessary precomputations have not been done)


### PR DESCRIPTION
This pr makes `secp256k1-zkp::Error` serializable and deserializable. The change is required so that [grin api v2](https://github.com/mimblewimble/grin/issues/2425) can use structured error types.