### PR TITLE
Functions to inverse and negate private key, commit with 2 blinding factors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "depend/secp256k1-zkp"]
 	path = depend/secp256k1-zkp
-	url = https://github.com/jaspervdm/secp256k1-zkp
+	url = https://github.com/mimblewimble/secp256k1-zkp

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "depend/secp256k1-zkp"]
 	path = depend/secp256k1-zkp
-	url = https://github.com/mimblewimble/secp256k1-zkp
+	url = https://github.com/jaspervdm/secp256k1-zkp

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -356,9 +356,13 @@ extern "C" {
                                        n: c_int)
                                        -> c_int;
 
-    pub fn secp256k1_ec_privkey_tweak_inverse(cx: *const Context,
-                                              sk: *mut c_uchar)
-                                              -> c_int;
+    pub fn secp256k1_ec_privkey_tweak_inv(cx: *const Context,
+                                          sk: *mut c_uchar)
+                                          -> c_int;
+
+    pub fn secp256k1_ec_privkey_tweak_neg(cx: *const Context,
+                                          sk: *mut c_uchar)
+                                          -> c_int;
 
     pub fn secp256k1_ecdh(cx: *const Context,
                           out: *mut SharedSecret,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -356,6 +356,10 @@ extern "C" {
                                        n: c_int)
                                        -> c_int;
 
+    pub fn secp256k1_ec_privkey_tweak_inverse(cx: *const Context,
+                                              sk: *mut c_uchar)
+                                              -> c_int;
+
     pub fn secp256k1_ecdh(cx: *const Context,
                           out: *mut SharedSecret,
                           point: *const PublicKey,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -394,6 +394,17 @@ extern "C" {
 		blind_gen: *const c_uchar
 	) -> c_int;
 
+    // Generates a pedersen commitment: *commit = blind * G + value * G2.
+	// The commitment is 33 bytes, the blinding factor and the value are 32 bytes.
+	pub fn secp256k1_pedersen_blind_commit(
+		ctx: *const Context,
+		commit: *mut c_uchar,
+		blind: *const c_uchar,
+		value: *const c_uchar,
+		value_gen: *const c_uchar,
+		blind_gen: *const c_uchar
+	) -> c_int;
+
 	// Get the public key of a pedersen commitment
 	pub fn secp256k1_pedersen_commitment_to_pubkey(
 	    cx: *const Context, pk: *mut PublicKey,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -394,7 +394,7 @@ extern "C" {
 		blind_gen: *const c_uchar
 	) -> c_int;
 
-    // Generates a pedersen commitment: *commit = blind * G + value * G2.
+	// Generates a pedersen commitment: *commit = blind * G + value * G2.
 	// The commitment is 33 bytes, the blinding factor and the value are 32 bytes.
 	pub fn secp256k1_pedersen_blind_commit(
 		ctx: *const Context,

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -1330,6 +1330,25 @@ mod tests {
 	}
 
 	#[test]
+	fn test_blind_commit() {
+		let secp = Secp256k1::with_caps(ContextFlag::Commit);
+		let rng = &mut thread_rng();
+		let value: u64 = 1;
+		let blind = SecretKey::new(&secp, rng);
+		let blind2 = ONE_KEY;
+		assert_eq!(secp.commit(value, blind.clone()).unwrap(), secp.commit_blind(blind2, blind.clone()).unwrap());
+		let value: u64 = 2;
+		let blind = SecretKey::new(&secp, rng);
+		assert_ne!(secp.commit(value, blind.clone()).unwrap(), secp.commit_blind(blind2, blind.clone()).unwrap());
+		let blind = SecretKey::new(&secp, rng);
+		let mut blind2 = ZERO_KEY;
+		blind2.0[30] = rng.gen::<u8>();
+		blind2.0[31] = rng.gen::<u8>();
+		let value: u64 = blind2[30] as u64*256 + blind2[31] as u64;
+		assert_eq!(secp.commit(value, blind.clone()).unwrap(), secp.commit_blind(blind2, blind.clone()).unwrap());
+	}
+
+	#[test]
 	fn test_range_proof() {
 		let secp = Secp256k1::with_caps(ContextFlag::Commit);
 		let blinding = SecretKey::new(&secp, &mut thread_rng());

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -415,6 +415,25 @@ impl Secp256k1 {
 		Ok(self.commit_ser(commit_i)?)
 	}
 
+	/// Creates a pedersen commitment from a two blinding factors
+	pub fn commit_blind(&self, value: SecretKey, blind: SecretKey) -> Result<Commitment, Error> {
+		if self.caps != ContextFlag::Commit {
+			return Err(Error::IncapableContext);
+		}
+		let mut commit_i = [0; constants::PEDERSEN_COMMITMENT_SIZE_INTERNAL];
+		unsafe {
+			ffi::secp256k1_pedersen_blind_commit(
+				self.ctx,
+				commit_i.as_mut_ptr(),
+				blind.as_ptr(),
+				value.as_ptr(),
+				constants::GENERATOR_H.as_ptr(),
+				constants::GENERATOR_G.as_ptr(),
+			)
+		};
+		Ok(self.commit_ser(commit_i)?)
+	}
+
 	/// Convenience method to Create a pedersen commitment only from a value,
 	/// with a zero blinding factor
 	pub fn commit_value(&self, value: u64) -> Result<Commitment, Error> {


### PR DESCRIPTION
Adds the 3 new functions from https://github.com/mimblewimble/secp256k1-zkp/pull/39 and corresponding tests