### PR TITLE
Fix build warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 
 build = "build.rs"
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0"
 
 [lib]
 name = "secp256k1zkp"

--- a/build.rs
+++ b/build.rs
@@ -21,10 +21,10 @@
 #![deny(unused_mut)]
 #![warn(missing_docs)]
 
-extern crate gcc;
+extern crate cc;
 
 fn main() {
-    let mut base_config = gcc::Build::new();
+    let mut base_config = cc::Build::new();
     base_config.include("depend/secp256k1-zkp/")
                .include("depend/secp256k1-zkp/include")
                .include("depend/secp256k1-zkp/src")


### PR DESCRIPTION
Switch from deprecated [gcc](https://crates.io/crates/gcc) to [cc](https://crates.io/crates/cc).