### PR TITLE
Fill SecretKey with zeros on Drop for security

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ libc = "0.2"
 rustc-serialize = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+zeroize = "0.8"
 
 [dev-dependencies]
 chrono = "0.4.5"

--- a/src/aggsig.rs
+++ b/src/aggsig.rs
@@ -389,7 +389,7 @@ mod tests {
 				msg, i, keypairs[i].0
 			);
 
-			let result = aggsig.partial_sign(msg, keypairs[i].0, i);
+			let result = aggsig.partial_sign(msg, keypairs[i].0.clone(), i);
 			match result {
 				Ok(ps) => {
 					println!("Partial sig: {:?}", ps);

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -23,7 +23,7 @@ use crate::key::{SecretKey, PublicKey};
 use crate::ffi;
 
 /// A tag used for recovering the public key from a compact signature
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct SharedSecret(ffi::SharedSecret);
 
 impl SharedSecret {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -69,12 +69,14 @@ pub type NonceFn = unsafe extern "C" fn(nonce32: *mut c_uchar,
 /// Generator
 #[repr(C)] 
 pub struct Generator(pub [c_uchar; 64]);
+impl Copy for Generator {}
 impl_array_newtype!(Generator, c_uchar, 64);
 impl_raw_debug!(Generator);
 
 /// Library-internal representation of a Secp256k1 public key
 #[repr(C)]
 pub struct PublicKey(pub [c_uchar; 64]);
+impl Copy for PublicKey {}
 impl_array_newtype!(PublicKey, c_uchar, 64);
 impl_raw_debug!(PublicKey);
 
@@ -88,18 +90,21 @@ impl PublicKey {
 /// Library-internal representation of a Secp256k1 signature
 #[repr(C)]
 pub struct Signature(pub [c_uchar; 64]);
+impl Copy for Signature {}
 impl_array_newtype!(Signature, c_uchar, 64);
 impl_raw_debug!(Signature);
 
 /// Library-internal representation of a Secp256k1 signature + recovery ID
 #[repr(C)]
 pub struct RecoverableSignature([c_uchar; 65]);
+impl Copy for RecoverableSignature {}
 impl_array_newtype!(RecoverableSignature, c_uchar, 65);
 impl_raw_debug!(RecoverableSignature);
 
 /// Library-internal representation of a Secp256k1 aggsig partial signature
 #[repr(C)]
 pub struct AggSigPartialSignature([c_uchar; 32]);
+impl Copy for AggSigPartialSignature {}
 impl_array_newtype!(AggSigPartialSignature, c_uchar, 32);
 impl_raw_debug!(AggSigPartialSignature);
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -26,7 +26,10 @@ use super::Error::{self, IncapableContext, InvalidPublicKey, InvalidSecretKey};
 use crate::constants;
 use crate::ffi;
 
+use zeroize::Zeroize;
+
 /// Secret 256-bit key used as `x` in an ECDSA signature
+#[derive(Zeroize)]
 pub struct SecretKey(pub [u8; constants::SECRET_KEY_SIZE]);
 impl_array_newtype!(SecretKey, u8, constants::SECRET_KEY_SIZE);
 impl_pretty_debug!(SecretKey);

--- a/src/key.rs
+++ b/src/key.rs
@@ -424,11 +424,11 @@ mod test {
         // Create buffer for blinding factor filled with non-zero bytes.
         let sk_bytes = ONE_KEY;
         let ptr = {
-            // Fill blinding factor with some "sensitive" data
+            // Fill blinding factor with some "sensitive" data.
             let sk = SecretKey::from_slice(&s, &sk_bytes[..]).unwrap();
             sk.0.as_ptr()
 
-            // -- after this line BlindingFactor should be zeroed
+            // -- after this line SecretKey should be zeroed.
         };
 
         // Unsafely get data from where SecretKey was in memory. Should be all zeros.

--- a/src/key.rs
+++ b/src/key.rs
@@ -412,6 +412,39 @@ mod test {
     use rand::{Error, RngCore, thread_rng};
     use self::rand_core::impls;
 
+    use std::slice::from_raw_parts;
+    use key::ONE_KEY;
+
+    // This tests cleaning of SecretKey (e.g. secret key) on Drop.
+    // To make this test fail, just remove `Zeroize` derive from `SecretKey` definition.
+    #[test]
+    fn skey_clear_on_drop() {
+        let s = Secp256k1::new();
+
+        // Create buffer for blinding factor filled with non-zero bytes.
+        let sk_bytes = ONE_KEY;
+        let ptr = {
+            // Fill blinding factor with some "sensitive" data
+            let sk = SecretKey::from_slice(&s, &sk_bytes[..]).unwrap();
+            sk.0.as_ptr()
+
+            // -- after this line BlindingFactor should be zeroed
+        };
+
+        // Unsafely get data from where SecretKey was in memory. Should be all zeros.
+        let sk_bytes = unsafe { from_raw_parts(ptr, constants::SECRET_KEY_SIZE) };
+
+        // There should be all zeroes.
+        let mut all_zeros = true;
+        for b in sk_bytes {
+            if *b != 0x00 {
+                all_zeros = false;
+            }
+        }
+
+        assert!(all_zeros)
+    }
+
     #[test]
     fn skey_from_slice() {
         let s = Secp256k1::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,8 +39,15 @@
 #![cfg_attr(all(test, feature = "unstable"), feature(test))]
 #[cfg(all(test, feature = "unstable"))] extern crate test;
 
+extern crate arrayvec;
 extern crate rustc_serialize as serialize;
+extern crate serde;
 extern crate serde_json as json;
+
+extern crate libc;
+extern crate rand;
+
+extern crate zeroize;
 
 use libc::size_t;
 use std::{error, fmt, ops, ptr};
@@ -414,6 +421,7 @@ impl ops::Index<ops::RangeFull> for Signature {
 
 /// A (hashed) message input to an ECDSA signature
 pub struct Message([u8; constants::MESSAGE_SIZE]);
+impl Copy for Message {}
 impl_array_newtype!(Message, u8, constants::MESSAGE_SIZE);
 impl_pretty_debug!(Message);
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -16,8 +16,6 @@
 // This is a macro that routinely comes in handy
 macro_rules! impl_array_newtype {
     ($thing:ident, $ty:ty, $len:expr) => {
-        impl Copy for $thing {}
-
         impl $thing {
             #[inline]
             /// Converts the object to a raw pointer for FFI interfacing


### PR DESCRIPTION
In response to https://github.com/mimblewimble/grin/issues/2218.
Corresponding PR in Grin: https://github.com/mimblewimble/grin/pull/2851

This PR:
* Adds [zeroize](https://crates.io/crates/zeroize) crate as dependency
* Adds `Zeroize` derive for `SecretKey` in a way that underlying byte array is filled with zeroes
* Removes `Copy` derive from `SecretKey` since it is impossible to implement both `Drop` and `Copy` at the same time. Implicit copying was replaced with more explicit `.clone()`
* Adds unit test for `SecretKey` zeroing

Some references:
https://github.com/dalek-cryptography/curve25519-dalek/issues/11
https://github.com/rust-lang/rfcs/issues/2533
https://www.youtube.com/watch?v=cQ9wTyYCdNU

*Feedback is highly appreciated!*