### PR TITLE
 Adding verify_batch wrapper around secp256k1_schnorrsig_verify_batch.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -41,7 +41,8 @@ fn main() {
                .define("ENABLE_MODULE_RECOVERY", Some("1"))
                .define("ENABLE_MODULE_RANGEPROOF", Some("1"))
                .define("ENABLE_MODULE_BULLETPROOF", Some("1"))
-               .define("ENABLE_MODULE_AGGSIG", Some("1"));
+               .define("ENABLE_MODULE_AGGSIG", Some("1"))
+               .define("ENABLE_MODULE_SCHNORRSIG", Some("1"));
 
     // secp256k1-zkp
     base_config.file("depend/secp256k1-zkp/contrib/lax_der_parsing.c")

--- a/src/aggsig.rs
+++ b/src/aggsig.rs
@@ -202,7 +202,7 @@ pub fn verify_batch(
 	msgs: &Vec<Message>,
 	pub_keys: &Vec<PublicKey>,
 ) -> bool {
-	let sigs_vec = map_vec!(sigs, |s| s.to_raw_data().as_ptr());
+	let sigs_vec = map_vec!(sigs, |s| s.0.as_ptr());
 	let msgs_vec = map_vec!(msgs, |m| m.as_ptr());
 	let pub_keys_vec = map_vec!(pub_keys, |pk| pk.as_ptr());
 
@@ -511,9 +511,9 @@ mod tests {
 			thread_rng().fill(&mut msg);
 
 			let msg = Message::from_slice(&msg).unwrap();
-			let sig = sign_single(&secp, &msg, &sk, None, None, None, None, None).unwrap();
+			let sig = sign_single(&secp, &msg, &sk, None, None, None, Some(&pk), None).unwrap();
 			
-			let result_single = verify_single(&secp, &sig, &msg, None, &pk, None, None, false);
+			let result_single = verify_single(&secp, &sig, &msg, None, &pk, Some(&pk), None, false);
 			assert!(result_single == true);
 			
 			pub_keys.push(pk);

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -319,6 +319,14 @@ extern "C" {
                                           is_partial: c_uint)
                                            -> c_int;
 
+    pub fn secp256k1_schnorrsig_verify_batch(cx: *const Context,
+		                                     scratch: *mut ScratchSpace,
+                                             sig: *const *const c_uchar,
+                                             msg32: *const *const c_uchar,
+                                             pk: *const *const PublicKey,
+                                             n_sigs: size_t)
+                                                -> c_int;
+
     pub fn secp256k1_aggsig_add_signatures_single(cx: *const Context,
                                                   ret_sig: *mut Signature,
                                                   sigs: *const *const c_uchar,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -320,12 +320,12 @@ extern "C" {
                                            -> c_int;
 
     pub fn secp256k1_schnorrsig_verify_batch(cx: *const Context,
-		                                     scratch: *mut ScratchSpace,
+                                             scratch: *mut ScratchSpace,
                                              sig: *const *const c_uchar,
                                              msg32: *const *const c_uchar,
                                              pk: *const *const PublicKey,
                                              n_sigs: size_t)
-                                                -> c_int;
+                                               -> c_int;
 
     pub fn secp256k1_aggsig_add_signatures_single(cx: *const Context,
                                                   ret_sig: *mut Signature,

--- a/src/key.rs
+++ b/src/key.rs
@@ -413,7 +413,7 @@ mod test {
     use self::rand_core::impls;
 
     use std::slice::from_raw_parts;
-    use key::ONE_KEY;
+    use crate::key::ONE_KEY;
 
     // This tests cleaning of SecretKey (e.g. secret key) on Drop.
     // To make this test fail, just remove `Zeroize` derive from `SecretKey` definition.


### PR DESCRIPTION
Using this new API should cut kernel signature verification time in half during initial sync.