### PR TITLE
zeroize: Upgrade to v0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ libc = "0.2"
 rustc-serialize = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-zeroize = "0.8"
+zeroize = "0.9"
 
 [dev-dependencies]
 chrono = "0.4.5"

--- a/src/key.rs
+++ b/src/key.rs
@@ -30,6 +30,7 @@ use zeroize::Zeroize;
 
 /// Secret 256-bit key used as `x` in an ECDSA signature
 #[derive(Zeroize)]
+#[zeroize(drop)]
 pub struct SecretKey(pub [u8; constants::SECRET_KEY_SIZE]);
 impl_array_newtype!(SecretKey, u8, constants::SECRET_KEY_SIZE);
 impl_pretty_debug!(SecretKey);


### PR DESCRIPTION
Hello, I'm the author of `zeroize`. This commit updates it to v0.9.

This crate presently seems to be the biggest user of zeroize v0.8 by downloads.

I'm trying to phase out (and eventually yank) v0.8 because it included an implicit Drop impl in its custom derive support, and I'm trying to backtrack on that and ensure it's always explicit (by using the `#[zeroize(drop)]` attribute). But before that, I want to make sure nobody is expecting an explicit `Drop` impl when one won't be provided.

Before I yank it, I want to ensure existing users are up-to-date.