### PR TITLE
Implement PartialOrd and Ord

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -55,7 +55,7 @@ pub const ONE_KEY: SecretKey = SecretKey([0, 0, 0, 0, 0, 0, 0, 0,
                                           0, 0, 0, 0, 0, 0, 0, 1]);
 
 /// A Secp256k1 public key, used for verification of signatures
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, PartialOrd, Ord, Hash)]
 pub struct PublicKey(pub ffi::PublicKey);
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ extern crate serde;
 extern crate serde_json as json;
 
 extern crate libc;
-extern crate rand;
+pub extern crate rand;
 
 extern crate zeroize;
 
@@ -61,6 +61,9 @@ pub mod ffi;
 pub mod key;
 pub mod pedersen;
 pub mod aggsig;
+
+pub use key::SecretKey;
+pub use key::PublicKey;
 
 /// A tag used for recovering the public key from a compact signature
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -55,19 +55,19 @@ macro_rules! impl_array_newtype {
 
         impl Eq for $thing {}
 
-		impl PartialOrd for $thing {
-			#[inline]
-			fn partial_cmp(&self, other: &$thing) -> Option<::core::cmp::Ordering> {
-				self[..].partial_cmp(&other[..])
-			}
-		}
+        impl PartialOrd for $thing {
+            #[inline]
+            fn partial_cmp(&self, other: &$thing) -> Option<::core::cmp::Ordering> {
+                self[..].partial_cmp(&other[..])
+            }
+        }
 
-		impl Ord for $thing {
-			#[inline]
-			fn cmp(&self, other: &$thing) -> ::core::cmp::Ordering {
-				self[..].cmp(&other[..])
-			}
-		}
+        impl Ord for $thing {
+            #[inline]
+            fn cmp(&self, other: &$thing) -> ::core::cmp::Ordering {
+                self[..].cmp(&other[..])
+            }
+        }
 
         impl Clone for $thing {
             #[inline]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -55,6 +55,20 @@ macro_rules! impl_array_newtype {
 
         impl Eq for $thing {}
 
+		impl PartialOrd for $thing {
+			#[inline]
+			fn partial_cmp(&self, other: &$thing) -> Option<::core::cmp::Ordering> {
+				self[..].partial_cmp(&other[..])
+			}
+		}
+
+		impl Ord for $thing {
+			#[inline]
+			fn cmp(&self, other: &$thing) -> ::core::cmp::Ordering {
+				self[..].cmp(&other[..])
+			}
+		}
+
         impl Clone for $thing {
             #[inline]
             fn clone(&self) -> $thing {


### PR DESCRIPTION
There are a bunch of types that are stored internally as a byte array, this PR implements `PartialOrd` and `Ord` for them. It's not a huge feature but it makes my life a bit easier :)