### PR TITLE
Add create commit from pubkey function

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -423,6 +423,11 @@ extern "C" {
 	    cx: *const Context, pk: *mut PublicKey,
 	    commit: *const c_uchar) -> c_int;
 
+	// Get a pedersen commitment from a pubkey
+	pub fn secp256k1_pubkey_to_pedersen_commitment(
+	    cx: *const Context, commit: *mut c_uchar,
+	    pk: *const PublicKey) -> c_int;
+
 	// Takes a list of n pointers to 32 byte blinding values, the first negs
 	// of which are treated with positive sign and the rest negative, then
 	// calculates an additional blinding value that adds to zero.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -460,6 +460,8 @@ pub enum Error {
     InvalidMessage,
     /// Bad public key
     InvalidPublicKey,
+    /// Bad commit
+    InvalidCommit,
     /// Bad signature
     InvalidSignature,
     /// Bad secret key
@@ -490,6 +492,7 @@ impl error::Error for Error {
             Error::IncorrectSignature => "secp: signature failed verification",
             Error::InvalidMessage => "secp: message was not 32 bytes (do you need to hash?)",
             Error::InvalidPublicKey => "secp: malformed public key",
+            Error::InvalidCommit => "secp: malformed commit",
             Error::InvalidSignature => "secp: malformed signature",
             Error::InvalidSecretKey => "secp: malformed or out-of-range secret key",
             Error::InvalidRecoveryId => "secp: bad recovery id",


### PR DESCRIPTION
Following on from https://github.com/mimblewimble/secp256k1-zkp/pull/54, adds the ffi function, `from_pubkey` Commit constructor and related test.