### PR TITLE
Commit to pubkey fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "grin_secp256k1zkp"
-version = "0.7.8"
+version = "0.7.9"
 authors = [ "Grin Developers <mimblewimble@lists.launchpad.net>",
 						"Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name = "grin_secp256k1zkp"
 version = "0.7.9"
 authors = [ "Grin Developers <mimblewimble@lists.launchpad.net>",
-						"Dawid Ciężarkiewicz <dpc@ucore.info>",
+            "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
 license = "CC0-1.0"
 homepage = "https://grin-tech.org"

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -98,9 +98,9 @@ impl Commitment {
 	/// Creates from a pubkey
 	pub fn from_pubkey(secp: &Secp256k1, pk: &key::PublicKey) -> Result<Self, Error> {
 		unsafe {
-			let mut commit = Self::blank();
-			if ffi::secp256k1_pubkey_to_pedersen_commitment(secp.ctx, commit.as_mut_ptr(), &pk.0) == 1 {
-				Ok(commit)
+			let mut commit_i = [0; constants::PEDERSEN_COMMITMENT_SIZE_INTERNAL];
+			if ffi::secp256k1_pubkey_to_pedersen_commitment(secp.ctx, commit_i.as_mut_ptr(), &pk.0 as *const _) == 1 {
+				Ok(secp.commit_ser(commit_i)?)
 			} else {
 				Err(InvalidCommit)
 			}


### PR DESCRIPTION
Previous versions of this appeared correct as they (for some reason) passed in both release and debug test modes. A few changes to the binary layout later and the release tests are crashing consistently.

Modifies the call to pubkey_to_pedersen_commit to use an internal commit representation.

Also bumps version number for next tag/release