### PR TITLE
Cut verification/signing etc. time at half for 64bit machines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ unstable = []
 default = []
 bullet-proof-sizing = []
 dev = ["clippy"]
+lowmemory = []
 
 [dependencies]
 arrayvec = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -21,21 +21,39 @@
 #![deny(unused_mut)]
 #![warn(missing_docs)]
 
+use std::env;
 fn main() {
+    if cfg!(feature = "external-symbols") {
+        println!("cargo:rustc-link-lib=static=secp256k1-zkp");
+        return;
+    }
+
+    // Check whether we can use 64-bit compilation
+    let use_64bit_compilation = if env::var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap() == "64" {
+        let check = cc::Build::new().file("depend/check_uint128_t.c")
+                                    .cargo_metadata(false)
+                                    .try_compile("check_uint128_t")
+                                    .is_ok();
+        if !check {
+            println!("cargo:warning=Compiling in 32-bit mode on a 64-bit architecture due to lack of uint128_t support.");
+        }
+        check
+    } else {
+        false
+    };
+
+    // Actual build
     let mut base_config = cc::Build::new();
     base_config.include("depend/secp256k1-zkp/")
                .include("depend/secp256k1-zkp/include")
                .include("depend/secp256k1-zkp/src")
-               .flag("-g")
+               .flag_if_supported("-Wno-unused-function") // some ecmult stuff is defined but not used upstream
+               .define("SECP256K1_BUILD", Some("1"))
                // TODO these three should be changed to use libgmp, at least until secp PR 290 is merged
                .define("USE_NUM_NONE", Some("1"))
                .define("USE_FIELD_INV_BUILTIN", Some("1"))
                .define("USE_SCALAR_INV_BUILTIN", Some("1"))
-               // TODO these should use 64-bit variants on 64-bit systems
-               .define("USE_FIELD_10X26", Some("1"))
-               .define("USE_SCALAR_8X32", Some("1"))
                .define("USE_ENDOMORPHISM", Some("1"))
-               // These all are OK.
                .define("ENABLE_MODULE_ECDH", Some("1"))
                .define("ENABLE_MODULE_GENERATOR", Some("1"))
                .define("ENABLE_MODULE_RECOVERY", Some("1"))
@@ -43,6 +61,27 @@ fn main() {
                .define("ENABLE_MODULE_BULLETPROOF", Some("1"))
                .define("ENABLE_MODULE_AGGSIG", Some("1"))
                .define("ENABLE_MODULE_SCHNORRSIG", Some("1"));
+
+    if cfg!(feature = "lowmemory") {
+        base_config.define("ECMULT_WINDOW_SIZE", Some("4")); // A low-enough value to consume neglible memory
+    } else {
+        base_config.define("ECMULT_WINDOW_SIZE", Some("15")); // This is the default in the configure file (`auto`)
+    }
+
+    if let Ok(target_endian) = env::var("CARGO_CFG_TARGET_ENDIAN") {
+        if target_endian == "big" {
+            base_config.define("WORDS_BIGENDIAN", Some("1"));
+        }
+    }
+
+    if use_64bit_compilation {
+        base_config.define("USE_FIELD_5X52", Some("1"))
+                   .define("USE_SCALAR_4X64", Some("1"))
+                   .define("HAVE___INT128", Some("1"));
+    } else {
+        base_config.define("USE_FIELD_10X26", Some("1"))
+                   .define("USE_SCALAR_8X32", Some("1"));
+    }
 
     // secp256k1-zkp
     base_config.file("depend/secp256k1-zkp/contrib/lax_der_parsing.c")

--- a/depend/check_uint128_t.c
+++ b/depend/check_uint128_t.c
@@ -1,0 +1,16 @@
+
+#include <stdint.h>
+
+int main(void) {
+    __uint128_t var_128;
+    uint64_t var_64;
+
+    /* Try to shut up "unused variable" warnings */
+    var_64 = 100;
+    var_128 = 100;
+    if (var_64 == var_128) {
+        var_64 = 20;
+    }
+    return 0;
+}
+

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -120,10 +120,9 @@ mod benches {
 
     #[bench]
     pub fn bench_ecdh(bh: &mut Bencher) {
-        let s = Secp256k1::with_caps(::ContextFlag::SignOnly);
+        let s = Secp256k1::new();
         let (sk, pk) = s.generate_keypair(&mut thread_rng()).unwrap();
 
-        let s = Secp256k1::new();
         bh.iter( || {
             let res = SharedSecret::new(&s, &pk, &sk);
             black_box(res);

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -2026,3 +2026,31 @@ mod tests {
 		assert_eq!(errs, 0);
 	}
 }
+
+
+
+
+#[cfg(all(test, feature = "unstable"))]
+mod benches {
+    use rand::thread_rng;
+    use test::{Bencher, black_box};
+	use super::{ContextFlag, SecretKey, Secp256k1};
+
+    #[bench]
+    pub fn bench_bullet_proof_verification(bh: &mut Bencher) {
+		// Test Bulletproofs without message
+		let secp = Secp256k1::with_caps(ContextFlag::Commit);
+		let blinding = SecretKey::new(&secp, &mut thread_rng());
+		let value = 12345678;
+		let commit = secp.commit(value, blinding.clone()).unwrap();
+		let bullet_proof = secp.bullet_proof(value, blinding.clone(), blinding.clone(), blinding.clone(), None, None);
+        bh.iter( || {
+			let proof_range = secp.verify_bullet_proof(commit, bullet_proof, None).unwrap();
+			assert_eq!(proof_range.min, 0);
+        });
+    }
+}
+
+
+
+


### PR DESCRIPTION
Hi,
This fork is quite an old fork of upstream, We've changed *a lot* since then.
https://github.com/rust-bitcoin/rust-secp256k1

On my 64bit laptop, before this PR:
```
test benches::bench_sign                                ... bench:      77,019 ns/iter (+/- 2,576)
test benches::bench_verify                              ... bench:      85,931 ns/iter (+/- 1,940)
test benches::generate                                  ... bench:      41,897 ns/iter (+/- 863)
test ecdh::benches::bench_ecdh                          ... bench:      79,895 ns/iter (+/- 1,975)
test pedersen::benches::bench_bullet_proof_verification ... bench:   3,393,491 ns/iter (+/- 102,317)
```

After:
```
test benches::bench_sign                                ... bench:      42,202 ns/iter (+/- 3,486)
test benches::bench_verify                              ... bench:      44,289 ns/iter (+/- 1,587)
test benches::generate                                  ... bench:      23,601 ns/iter (+/- 626)
test ecdh::benches::bench_ecdh                          ... bench:      48,662 ns/iter (+/- 2,532)
test pedersen::benches::bench_bullet_proof_verification ... bench:   1,868,231 ns/iter (+/- 82,517)
```

I do suggest to merge/rebase this on/from upstream, or manually copy the changes you want because the library had gotten a lot better.
These are just some examples of good/important changes we've done to the library:
https://github.com/rust-bitcoin/rust-secp256k1/pull/146
https://github.com/rust-bitcoin/rust-secp256k1/pull/125
https://github.com/rust-bitcoin/rust-secp256k1/pull/120
https://github.com/rust-bitcoin/rust-secp256k1/pull/115
https://github.com/rust-bitcoin/rust-secp256k1/pull/100
https://github.com/rust-bitcoin/rust-secp256k1/pull/87
https://github.com/rust-bitcoin/rust-secp256k1/pull/78
https://github.com/rust-bitcoin/rust-secp256k1/pull/64
https://github.com/rust-bitcoin/rust-secp256k1/pull/51
https://github.com/rust-bitcoin/rust-secp256k1/pull/27 