### PR TITLE
Update zeroize dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ libc = "0.2"
 rustc-serialize = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-zeroize = "0.9"
+zeroize = { version = "1.1", features = ["zeroize_derive"] }
 
 [dev-dependencies]
 chrono = "0.4.5"


### PR DESCRIPTION
Minimal update to earliest supported version of the `zeroize` crate. Versions lower than `1.0.0`  were pulled from [crates.io](https://docs.rs/zeroize/0.9.0/zeroize/?search=Zeroize).