### PR TITLE
Fix repository url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = [ "Grin Developers <mimblewimble@lists.launchpad.net>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
 license = "CC0-1.0"
 homepage = "https://grin.mw"
-repository = "https://github.com/mimblewimble/rust-secp256k1/"
+repository = "https://github.com/mimblewimble/rust-secp256k1-zkp/"
 description = "Grin's fork with Zero-Knowledge extensions of Rust bindings for Pieter Wuille's `libsecp256k1` library. Implements ECDSA for the SECG elliptic curve group secp256k1 and related utilities."
 keywords = [ "crypto", "secp256k1", "grin", "bitcoin", "zero-knowledge" ]
 readme = "README.md"


### PR DESCRIPTION
Fix repository url from `https://github.com/mimblewimble/rust-secp256k1/` to `https://github.com/mimblewimble/rust-secp256k1-zkp/`.