### PR TITLE
Aggsig signature subtraction function, rust side

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "grin_secp256k1zkp"
-version = "0.7.11"
+version = "0.7.12"
 authors = [ "Grin Developers <mimblewimble@lists.launchpad.net>",
             "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]

--- a/src/aggsig.rs
+++ b/src/aggsig.rs
@@ -792,29 +792,11 @@ use crate::ffi;
 
 			// Subtract sig1 from final sig
 			let (res_sig, res_sig_opt) = subtract_partial_signature(&secp, &final_sig, &sig1).unwrap();
-			let mut sig_matches = false;
-			if res_sig == sig2 {
-				sig_matches = true;
-			} else if let Some(r) = res_sig_opt {
-				if r == sig2 {
-					sig_matches = true;
-				}
-			}
-			assert!(sig_matches == true);
+			assert!(res_sig == sig2 || res_sig_opt == Some(sig2));
 
 			// Subtract sig2 from final sig for good measure
 			let (res_sig, res_sig_opt) = subtract_partial_signature(&secp, &final_sig, &sig2).unwrap();
-			sig_matches = false;
-			if res_sig == sig1 {
-				sig_matches = true;
-			} else if let Some(r) = res_sig_opt {
-				if r == sig1 {
-					sig_matches = true;
-				}
-			}
-			assert!(sig_matches == true);
-
-
+			assert!(res_sig == sig1 || res_sig_opt == Some(sig1));
 		}
 	}
 }

--- a/src/aggsig.rs
+++ b/src/aggsig.rs
@@ -281,12 +281,11 @@ pub fn subtract_partial_signature(
 		)
 	};
 
-	if retval == 1 {
-		Ok((ret_partsig, None))
-	} else if retval == 2 {
-		Ok((ret_partsig, Some(ret_partsig_alt)))
-	} else {
-		Err(Error::InvalidSignature)
+	match retval {
+		-1 => Err(Error::SigSubtractionFailure),
+		1 => Ok((ret_partsig, None)),
+		2 => Ok((ret_partsig, Some(ret_partsig_alt))),
+		_ => Err(Error::InvalidSignature)
 	}
 }
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -333,7 +333,15 @@ extern "C" {
                                                   num_sigs: size_t,
                                                   pubnonce_total: *const PublicKey)
                                                       -> c_int;
-    // EC
+
+    pub fn secp256k1_aggsig_subtract_partial_signature(cx: *const Context,
+                                                  ret_partsig: *mut Signature,
+                                                  ret_partsig_alt: *mut Signature,
+                                                  sig: *const Signature,
+                                                  part_sig: *const Signature)
+                                                      -> c_int;
+
+     // EC
     pub fn secp256k1_ec_seckey_verify(cx: *const Context,
                                       sk: *const c_uchar) -> c_int;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -477,6 +477,8 @@ pub enum Error {
     InvalidRangeProof,
     /// Error creating partial signature
     PartialSigFailure,
+    /// Failure subtracting two signatures
+    SigSubtractionFailure,
 }
 
 impl Error {
@@ -493,6 +495,7 @@ impl Error {
             Error::IncorrectCommitSum => "secp: invalid pedersen commitment sum",
             Error::InvalidRangeProof => "secp: invalid range proof",
             Error::PartialSigFailure => "secp: partial sig (aggsig) failure",
+            Error::SigSubtractionFailure => "secp: subtraction (aggsig) did not result in any valid signatures",
         }
     }
 }


### PR DESCRIPTION
Note this depends on: https://github.com/mimblewimble/secp256k1-zkp/pull/67, that will need to be merged and the submodule updated before this change can be commit.

The rust FFI interface + api implementation of `subtract_partial_signature`, along with some test additions to exercise and verify it. Will only be used in the experimental contracts wallet branch for early payment proof verification. 