### PR TITLE
Remove rustc-serialize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ arrayvec = "0.3"
 clippy = {version = "0.0", optional = true}
 rand = "0.5"
 libc = "0.2"
-rustc-serialize = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 zeroize = { version = "1.1", features = ["zeroize_derive"] }

--- a/src/key.rs
+++ b/src/key.rs
@@ -497,68 +497,6 @@ mod test {
     }
 
     #[test]
-    fn test_bad_deserialize() {
-        use std::io::Cursor;
-        use crate::serialize::{json, Decodable};
-
-        let zero31 = "[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]".as_bytes();
-        let json31 = json::Json::from_reader(&mut Cursor::new(zero31)).unwrap();
-        let zero32 = "[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]".as_bytes();
-        let json32 = json::Json::from_reader(&mut Cursor::new(zero32)).unwrap();
-        let zero65 = "[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]".as_bytes();
-        let json65 = json::Json::from_reader(&mut Cursor::new(zero65)).unwrap();
-        let string = "\"my key\"".as_bytes();
-        let json = json::Json::from_reader(&mut Cursor::new(string)).unwrap();
-
-        // Invalid length
-        let mut decoder = json::Decoder::new(json31.clone());
-        assert!(<PublicKey as Decodable>::decode(&mut decoder).is_err());
-        let mut decoder = json::Decoder::new(json31.clone());
-        assert!(<SecretKey as Decodable>::decode(&mut decoder).is_err());
-        let mut decoder = json::Decoder::new(json32.clone());
-        assert!(<PublicKey as Decodable>::decode(&mut decoder).is_err());
-        let mut decoder = json::Decoder::new(json32.clone());
-        assert!(<SecretKey as Decodable>::decode(&mut decoder).is_ok());
-        let mut decoder = json::Decoder::new(json65.clone());
-        assert!(<PublicKey as Decodable>::decode(&mut decoder).is_err());
-        let mut decoder = json::Decoder::new(json65.clone());
-        assert!(<SecretKey as Decodable>::decode(&mut decoder).is_err());
-
-        // Syntax error
-        let mut decoder = json::Decoder::new(json.clone());
-        assert!(<PublicKey as Decodable>::decode(&mut decoder).is_err());
-        let mut decoder = json::Decoder::new(json.clone());
-        assert!(<SecretKey as Decodable>::decode(&mut decoder).is_err());
-    }
-
-    #[test]
-    fn test_serialize() {
-        use std::io::Cursor;
-
-        macro_rules! round_trip (
-            ($var:ident) => ({
-                let start = $var;
-                let mut encoded = String::new();
-                {
-                    let mut encoder = json::Encoder::new(&mut encoded);
-                    start.encode(&mut encoder).unwrap();
-                }
-                let json = json::Json::from_reader(&mut Cursor::new(encoded.as_bytes())).unwrap();
-                let mut decoder = json::Decoder::new(json);
-                let decoded = Decodable::decode(&mut decoder);
-                assert_eq!(Ok(Some(start)), decoded);
-            })
-        );
-
-        let s = Secp256k1::new();
-        for _ in 0..500 {
-            let (sk, pk) = s.generate_keypair(&mut thread_rng()).unwrap();
-            round_trip!(sk);
-            round_trip!(pk);
-        }
-    }
-
-    #[test]
     fn test_bad_serde_deserialize() {
         use serde::Deserialize;
         use crate::json;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -714,8 +714,6 @@ mod tests {
     use super::Error::{InvalidMessage, InvalidPublicKey, IncorrectSignature, InvalidSignature,
                        IncapableContext};
 
-    macro_rules! hex (($hex:expr) => ($hex.from_hex().unwrap()));
-
     #[test]
     fn capabilities() {
         let none = Secp256k1::with_caps(ContextFlag::None);
@@ -840,25 +838,6 @@ mod tests {
             assert!(Signature::from_der(&s, &compact[..]).is_err());
             assert!(Signature::from_der(&s, &der[0..4]).is_err());
          }
-    }
-
-    #[test]
-    fn signature_lax_der() {
-        macro_rules! check_lax_sig(
-            ($hex:expr) => ({
-                let secp = Secp256k1::without_caps();
-                let sig = hex!($hex);
-                assert!(Signature::from_der_lax(&secp, &sig[..]).is_ok());
-            })
-        );
-
-        check_lax_sig!("304402204c2dd8a9b6f8d425fcd8ee9a20ac73b619906a6367eac6cb93e70375225ec0160220356878eff111ff3663d7e6bf08947f94443845e0dcc54961664d922f7660b80c");
-        check_lax_sig!("304402202ea9d51c7173b1d96d331bd41b3d1b4e78e66148e64ed5992abd6ca66290321c0220628c47517e049b3e41509e9d71e480a0cdc766f8cdec265ef0017711c1b5336f");
-        check_lax_sig!("3045022100bf8e050c85ffa1c313108ad8c482c4849027937916374617af3f2e9a881861c9022023f65814222cab09d5ec41032ce9c72ca96a5676020736614de7b78a4e55325a");
-        check_lax_sig!("3046022100839c1fbc5304de944f697c9f4b1d01d1faeba32d751c0f7acb21ac8a0f436a72022100e89bd46bb3a5a62adc679f659b7ce876d83ee297c7a5587b2011c4fcc72eab45");
-        check_lax_sig!("3046022100eaa5f90483eb20224616775891397d47efa64c68b969db1dacb1c30acdfc50aa022100cf9903bbefb1c8000cf482b0aeeb5af19287af20bd794de11d82716f9bae3db1");
-        check_lax_sig!("3045022047d512bc85842ac463ca3b669b62666ab8672ee60725b6c06759e476cebdc6c102210083805e93bd941770109bcc797784a71db9e48913f702c56e60b1c3e2ff379a60");
-        check_lax_sig!("3044022023ee4e95151b2fbbb08a72f35babe02830d14d54bd7ed1320e4751751d1baa4802206235245254f58fd1be6ff19ca291817da76da65c2f6d81d654b5185dd86b8acf");
     }
 
     #[test]
@@ -1031,27 +1010,6 @@ mod tests {
         assert_eq!(id0.to_i32(), 0);
         let id1 = RecoveryId(1);
         assert_eq!(id1.to_i32(), 1);
-    }
-
-    #[test]
-    fn test_low_s() {
-        // nb this is a transaction on testnet
-        // txid 8ccc87b72d766ab3128f03176bb1c98293f2d1f85ebfaf07b82cc81ea6891fa9
-        //      input number 3
-        let sig = hex!("3046022100839c1fbc5304de944f697c9f4b1d01d1faeba32d751c0f7acb21ac8a0f436a72022100e89bd46bb3a5a62adc679f659b7ce876d83ee297c7a5587b2011c4fcc72eab45");
-        let pk = hex!("031ee99d2b786ab3b0991325f2de8489246a6a3fdb700f6d0511b1d80cf5f4cd43");
-        let msg = hex!("a4965ca63b7d8562736ceec36dfa5a11bf426eb65be8ea3f7a49ae363032da0d");
-
-        let secp = Secp256k1::new();
-        let mut sig = Signature::from_der(&secp, &sig[..]).unwrap();
-        let pk = PublicKey::from_slice(&secp, &pk[..]).unwrap();
-        let msg = Message::from_slice(&msg[..]).unwrap();
-
-        // without normalization we expect this will fail
-        assert_eq!(secp.verify(&msg, &sig, &pk), Err(IncorrectSignature));
-        // after normalization it should pass
-        sig.normalize_s(&secp);
-        assert_eq!(secp.verify(&msg, &sig, &pk), Ok(()));
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(warnings)]
 // Bitcoin secp256k1 bindings
 // Written in 2014 by
 //   Dawid Ciężarkiewicz
@@ -40,7 +41,6 @@
 #[cfg(all(test, feature = "unstable"))] extern crate test;
 
 extern crate arrayvec;
-extern crate rustc_serialize as serialize;
 extern crate serde;
 extern crate serde_json as json;
 
@@ -708,7 +708,6 @@ impl Secp256k1 {
 #[cfg(test)]
 mod tests {
     use rand::{Rng, thread_rng};
-    use crate::serialize::hex::FromHex;
     use crate::key::{SecretKey, PublicKey};
     use super::constants;
     use super::{Secp256k1, Signature, RecoverableSignature, Message, RecoveryId, ContextFlag};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -143,34 +143,6 @@ macro_rules! impl_array_newtype {
           }
         }
 
-        impl crate::serialize::Decodable for $thing {
-            fn decode<D: crate::serialize::Decoder>(d: &mut D) -> Result<$thing, D::Error> {
-                use crate::serialize::Decodable;
-
-                d.read_seq(|d, len| {
-                    if len != $len {
-                        Err(d.error("Invalid length"))
-                    } else {
-                        unsafe {
-                            use std::mem;
-                            let mut ret: [$ty; $len] = mem::MaybeUninit::uninit().assume_init();
-                            for i in 0..len {
-                                ret[i] = d.read_seq_elt(i, |d| Decodable::decode(d))?;
-                            }
-                            Ok($thing(ret))
-                        }
-                    }
-                })
-            }
-        }
-
-        impl crate::serialize::Encodable for $thing {
-            fn encode<S: crate::serialize::Encoder>(&self, s: &mut S)
-                                               -> Result<(), S::Error> {
-                self[..].encode(s)
-            }
-        }
-
         impl<'de> ::serde::Deserialize<'de> for $thing {
             fn deserialize<D>(d: D) -> Result<$thing, D::Error>
                 where D: ::serde::Deserializer<'de>


### PR DESCRIPTION
This crate will have difficulties being updated to future compilers if it continues to depend on rustc-serialize. This PR updates it to remove this dependency. Not all tests pass on my machine but this appears to be due to preexisting unsoundness in the library's test suite:

```
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.01s
warning: the following packages contain code that will be rejected by a future version of Rust: grin_secp256k1zkp v0.7.12 (/home/jubilee/rust/rust-secp256k1-zkp)
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 2`
     Running unittests src/lib.rs (target/debug/deps/secp256k1zkp-6adad85efc3e032c)

running 56 tests
test key::test::test_bad_serde_deserialize ... ok
test ecdh::tests::ecdh ... ok
test key::test::invalid_secret_key ... ok
test key::test::pubkey_from_slice ... ok
test key::test::skey_from_slice ... ok
test key::test::test_debug_output ... ok
test aggsig::tests::test_aggsig_fuzz ... ok
test key::test::skey_clear_on_drop ... ok
thread 'key::test::keypair_slice_round_trip' panicked at library/core/src/panicking.rs:152:5:
unsafe precondition(s) violated: slice::get_unchecked_mut requires that the index is within the slice
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread caused non-unwinding panic. aborting.
error: test failed, to rerun pass `--lib`

Caused by:
  process didn't exit successfully: `/home/jubilee/rust/rust-secp256k1-zkp/target/debug/deps/secp256k1zkp-6adad85efc3e032c` (signal: 6, SIGABRT: process abort signal)
```