### PR TITLE
Fix RangeProof::clone() memory corruption and remove rustc-serialize dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "grin_secp256k1zkp"
-version = "0.7.12"
+version = "0.7.13"
 authors = [ "Grin Developers <mimblewimble@lists.launchpad.net>",
             "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
@@ -32,7 +32,6 @@ arrayvec = "0.3"
 clippy = {version = "0.0", optional = true}
 rand = "0.5"
 libc = "0.2"
-rustc-serialize = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 zeroize = { version = "1.1", features = ["zeroize_derive"] }

--- a/src/key.rs
+++ b/src/key.rs
@@ -18,7 +18,6 @@
 use std::marker;
 use arrayvec::ArrayVec;
 use rand::Rng;
-use crate::serialize::{Decoder, Decodable, Encoder, Encodable};
 use serde::{Serialize, Deserialize, Serializer, Deserializer};
 
 use super::{Secp256k1, ContextFlag};
@@ -288,48 +287,12 @@ impl PublicKey {
     }
 }
 
-impl Decodable for PublicKey {
-    fn decode<D: Decoder>(d: &mut D) -> Result<PublicKey, D::Error> {
-        d.read_seq(|d, len| {
-            let s = Secp256k1::with_caps(crate::ContextFlag::None);
-            if len == constants::UNCOMPRESSED_PUBLIC_KEY_SIZE {
-                unsafe {
-                    use std::mem;
-                    let mut ret: [u8; constants::UNCOMPRESSED_PUBLIC_KEY_SIZE] = mem::MaybeUninit::uninit().assume_init();
-                    for i in 0..len {
-                        ret[i] = d.read_seq_elt(i, |d| Decodable::decode(d))?;
-                    }
-                    PublicKey::from_slice(&s, &ret).map_err(|_| d.error("invalid public key"))
-                }
-            } else if len == constants::COMPRESSED_PUBLIC_KEY_SIZE {
-                unsafe {
-                    use std::mem;
-                    let mut ret: [u8; constants::COMPRESSED_PUBLIC_KEY_SIZE] = mem::MaybeUninit::uninit().assume_init();
-                    for i in 0..len {
-                        ret[i] = d.read_seq_elt(i, |d| Decodable::decode(d))?;
-                    }
-                    PublicKey::from_slice(&s, &ret).map_err(|_| d.error("invalid public key"))
-                }
-            } else {
-                Err(d.error("Invalid length"))
-            }
-        })
-    }
-}
 
 /// Creates a new public key from a FFI public key
 impl From<ffi::PublicKey> for PublicKey {
     #[inline]
     fn from(pk: ffi::PublicKey) -> PublicKey {
         PublicKey(pk)
-    }
-}
-
-
-impl Encodable for PublicKey {
-    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-        let secp = Secp256k1::with_caps(crate::ContextFlag::None);
-        self.serialize_vec(&secp, true).encode(s)
     }
 }
 
@@ -531,69 +494,6 @@ mod test {
 
         let s = Secp256k1::with_caps(ContextFlag::None);
         assert_eq!(pk.add_exp_assign(&s, &sk), Err(IncapableContext));
-    }
-
-    #[test]
-    fn test_bad_deserialize() {
-        use std::io::Cursor;
-        use crate::serialize::{json, Decodable};
-
-        let zero31 = "[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]".as_bytes();
-        let json31 = json::Json::from_reader(&mut Cursor::new(zero31)).unwrap();
-        let zero32 = "[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]".as_bytes();
-        let json32 = json::Json::from_reader(&mut Cursor::new(zero32)).unwrap();
-        let zero65 = "[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]".as_bytes();
-        let json65 = json::Json::from_reader(&mut Cursor::new(zero65)).unwrap();
-        let string = "\"my key\"".as_bytes();
-        let json = json::Json::from_reader(&mut Cursor::new(string)).unwrap();
-
-        // Invalid length
-        let mut decoder = json::Decoder::new(json31.clone());
-        assert!(<PublicKey as Decodable>::decode(&mut decoder).is_err());
-        let mut decoder = json::Decoder::new(json31.clone());
-        assert!(<SecretKey as Decodable>::decode(&mut decoder).is_err());
-        let mut decoder = json::Decoder::new(json32.clone());
-        assert!(<PublicKey as Decodable>::decode(&mut decoder).is_err());
-        let mut decoder = json::Decoder::new(json32.clone());
-        assert!(<SecretKey as Decodable>::decode(&mut decoder).is_ok());
-        let mut decoder = json::Decoder::new(json65.clone());
-        assert!(<PublicKey as Decodable>::decode(&mut decoder).is_err());
-        let mut decoder = json::Decoder::new(json65.clone());
-        assert!(<SecretKey as Decodable>::decode(&mut decoder).is_err());
-
-        // Syntax error
-        let mut decoder = json::Decoder::new(json.clone());
-        assert!(<PublicKey as Decodable>::decode(&mut decoder).is_err());
-        let mut decoder = json::Decoder::new(json.clone());
-        assert!(<SecretKey as Decodable>::decode(&mut decoder).is_err());
-    }
-
-    #[test]
-    fn test_serialize() {
-        use std::io::Cursor;
-        use crate::serialize::{json, Decodable, Encodable};
-
-        macro_rules! round_trip (
-            ($var:ident) => ({
-                let start = $var;
-                let mut encoded = String::new();
-                {
-                    let mut encoder = json::Encoder::new(&mut encoded);
-                    start.encode(&mut encoder).unwrap();
-                }
-                let json = json::Json::from_reader(&mut Cursor::new(encoded.as_bytes())).unwrap();
-                let mut decoder = json::Decoder::new(json);
-                let decoded = Decodable::decode(&mut decoder);
-                assert_eq!(Ok(Some(start)), decoded);
-            })
-        );
-
-        let s = Secp256k1::new();
-        for _ in 0..500 {
-            let (sk, pk) = s.generate_keypair(&mut thread_rng()).unwrap();
-            round_trip!(sk);
-            round_trip!(pk);
-        }
     }
 
     #[test]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -143,34 +143,6 @@ macro_rules! impl_array_newtype {
           }
         }
 
-        impl crate::serialize::Decodable for $thing {
-            fn decode<D: crate::serialize::Decoder>(d: &mut D) -> Result<$thing, D::Error> {
-                use crate::serialize::Decodable;
-
-                d.read_seq(|d, len| {
-                    if len != $len {
-                        Err(d.error("Invalid length"))
-                    } else {
-                        unsafe {
-                            use std::mem;
-                            let mut ret: [$ty; $len] = mem::MaybeUninit::uninit().assume_init();
-                            for i in 0..len {
-                                ret[i] = d.read_seq_elt(i, |d| Decodable::decode(d))?;
-                            }
-                            Ok($thing(ret))
-                        }
-                    }
-                })
-            }
-        }
-
-        impl crate::serialize::Encodable for $thing {
-            fn encode<S: crate::serialize::Encoder>(&self, s: &mut S)
-                                               -> Result<(), S::Error> {
-                self[..].encode(s)
-            }
-        }
-
         impl<'de> ::serde::Deserialize<'de> for $thing {
             fn deserialize<D>(d: D) -> Result<$thing, D::Error>
                 where D: ::serde::Deserializer<'de>
@@ -256,7 +228,7 @@ macro_rules! map_vec {
   ($thing:expr, $mapfn:expr ) => {
     $thing.iter()
       .map($mapfn)
-      .collect::<Vec<_>>();
+      .collect::<Vec<_>>()
   }
 }
 

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -146,7 +146,7 @@ impl Clone for RangeProof {
 			copy_nonoverlapping(
 				self.proof.as_ptr(),
 				ret.as_mut_ptr(),
-				mem::size_of::<RangeProof>(),
+				self.plen,
 			);
 			RangeProof {
 				proof: ret,


### PR DESCRIPTION
The previous code was copying beyond the buffer, which resulted in memory corruption. I change it from copying `mem::size_of::<RangeProof>()` bytes, which included the additional `plen` field, to just `self.plen` bytes.

I also removed the rustc-serialize dependency, which prevents us from building with newer rust versions.

The tests all pass for me with these changes.