### PR TITLE
Update ArrayVec crate to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ bullet-proof-sizing = []
 dev = ["clippy"]
 
 [dependencies]
-arrayvec = "0.3"
+arrayvec = "0.7"
 clippy = {version = "0.0", optional = true}
 rand = "0.5"
 libc = "0.2"

--- a/src/key.rs
+++ b/src/key.rs
@@ -237,7 +237,7 @@ impl PublicKey {
     /// Serialize the key as a byte-encoded pair of values. In compressed form
     /// the y-coordinate is represented by only a single bit, as x determines
     /// it up to one bit.
-    pub fn serialize_vec(&self, secp: &Secp256k1, compressed: bool) -> ArrayVec<[u8; constants::PUBLIC_KEY_SIZE]> {
+    pub fn serialize_vec(&self, secp: &Secp256k1, compressed: bool) -> ArrayVec<u8, {constants::PUBLIC_KEY_SIZE}> {
         let mut ret = ArrayVec::new();
 
         unsafe {


### PR DESCRIPTION
Previous to this, on latest version of Rust (1.78), the `serialize_vec` function was failing due to additional debug assertions in Rust:

```
'unsafe precondition(s) violated: slice::get_unchecked_mut requires that the index is within the slice': library/core/src/panicking.rs:215 
```

Note that our existing code isn't incorrect; `ArrayVec` allocates fixed memory according to its capacity (in this case setting its capacity to `constants::PUBLIC_KEY_SIZE` or 72). (This is made clearer by the newer parameter format of ArrayVec). `secp256k1_ec_pubkey_serialize` returns the actual length according to whether the result is compressed or uncompressed and we call `ArrayVec::set_len()` to set the actual length of the data, which is where the problematic assertion is being raised. This appears to be due to an issue in earlier versions of the `ArrayVec` crate, which seems to have been resolved in the latest.