### PR TITLE
Fix UAF bug in AggSigContext

### DIFF
--- a/src/aggsig.rs
+++ b/src/aggsig.rs
@@ -293,7 +293,7 @@ pub fn subtract_partial_signature(
 
 /// Manages an instance of an aggsig multisig context, and provides all methods
 /// to act on that context
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct AggSigContext {
 	ctx: *mut ffi::Context,
 	aggsig_ctx: *mut ffi::AggSigContext,


### PR DESCRIPTION
The `AggSigContext` type contains a raw pointer to an external memory object and has a derived `Clone` implementation. If `Clone` is called on `AggSigContext` a new alias is created.

```rust
#[derive(Clone, Debug)]
pub struct AggSigContext {
	ctx: *mut ffi::Context,
	aggsig_ctx: *mut ffi::AggSigContext,
}
```
The `Drop` implementation for `AggSigContext` frees unconditionally.

```rust
impl Drop for AggSigContext {
      fn drop(&mut self) {
              unsafe {
                      ffi::secp256k1_aggsig_context_destroy(self.aggsig_ctx);
              }
      }
}
```

If an instance of `AggSigContext` is cloned and `Drop` is called on both the original instance and the clone a use-after-free occurs.

## Reproduction:

### Test case:

```rust
use secp256k1zkp::aggsig::AggSigContext;
use secp256k1zkp::key::{PublicKey, SecretKey};
use secp256k1zkp::Secp256k1;

#[test]
fn clone_then_drop_double_free() {
    let secp = Secp256k1::new();
    let sk = SecretKey::from_slice(&secp, &[1u8; 32]).unwrap();
    let pk = PublicKey::from_secret_key(&secp, &sk).unwrap();
    let a = AggSigContext::new(&secp, &vec![pk]);
    let b = a.clone();
    drop(a);
    drop(b); // double free
}
```

### Verification:
```
cargo test -p grin_secp256k1zkp --test aggsig_double_free --no-run
valgrind --leak-check=no ./target/debug/deps/aggsig_double_free-<hash>
```
### Valgrind output: 
```
==302287== Thread 2 aggsig_context_:
==302287== Invalid read of size 8
==302287==    at 0x19AEE2: secp256k1_aggsig_context_destroy (main_impl.h:731)
==302287==    by 0x18CDBE: <secp256k1zkp::aggsig::AggSigContext as core::ops::drop::Drop>::drop (aggsig.rs:415)
==302287==    by 0x14CA5A: core::ptr::drop_in_place<secp256k1zkp::aggsig::AggSigContext> (mod.rs:805)
==302287==    by 0x14CB17: core::mem::drop (mod.rs:975)
==302287==    by 0x14D499: aggsig_double_free::aggsig_context_clone_double_free (aggsig_double_free.rs:16)
==302287==    by 0x14CEF6: aggsig_double_free::aggsig_context_clone_double_free::{{closure}} (aggsig_double_free.rs:9)
==302287==    by 0x14CA15: core::ops::function::FnOnce::call_once (function.rs:250)
==302287==    by 0x14DA2A: call_once<fn() -> core::result::Result<(), alloc::string::String>, ()> (function.rs:250)
==302287==    by 0x14DA2A: test::__rust_begin_short_backtrace::<core::result::Result<(), alloc::string::String>, fn() -> core::result::Result<(), alloc::string::String>> (lib.rs:663)
==302287==    by 0x15A41A: {closure#0} (lib.rs:686)
==302287==    by 0x15A41A: call_once<core::result::Result<(), alloc::string::String>, test::run_test_in_process::{closure_env#0}> (unwind_safe.rs:274)
==302287==    by 0x15A41A: do_call<core::panic::unwind_safe::AssertUnwindSafe<test::run_test_in_process::{closure_env#0}>, core::result::Result<(), alloc::string::String>> (panicking.rs:581)
==302287==    by 0x15A41A: catch_unwind<core::result::Result<(), alloc::string::String>, core::panic::unwind_safe::AssertUnwindSafe<test::run_test_in_process::{closure_env#0}>> (panicking.rs:544)
==302287==    by 0x15A41A: catch_unwind<core::panic::unwind_safe::AssertUnwindSafe<test::run_test_in_process::{closure_env#0}>, core::result::Result<(), alloc::string::String>> (panic.rs:359)
==302287==    by 0x15A41A: run_test_in_process (lib.rs:686)
==302287==    by 0x15A41A: test::run_test::{closure#0} (lib.rs:607)
==302287==    by 0x155B33: {closure#1} (lib.rs:637)
==302287==    by 0x155B33: std::sys::backtrace::__rust_begin_short_backtrace::<test::run_test::{closure#1}, ()> (backtrace.rs:166)
==302287==    by 0x15D021: {closure#0}<test::run_test::{closure_env#1}, ()> (lifecycle.rs:91)
==302287==    by 0x15D021: call_once<(), std::thread::lifecycle::spawn_unchecked::{closure#1}::{closure_env#0}<test::run_test::{closure_env#1}, ()>> (unwind_safe.rs:274)
==302287==    by 0x15D021: do_call<core::panic::unwind_safe::AssertUnwindSafe<std::thread::lifecycle::spawn_unchecked::{closure#1}::{closure_env#0}<test::run_test::{closure_env#1}, ()>>, ()> (panicking.rs:581)
==302287==    by 0x15D021: catch_unwind<(), core::panic::unwind_safe::AssertUnwindSafe<std::thread::lifecycle::spawn_unchecked::{closure#1}::{closure_env#0}<test::run_test::{closure_env#1}, ()>>> (panicking.rs:544)
==302287==    by 0x15D021: catch_unwind<core::panic::unwind_safe::AssertUnwindSafe<std::thread::lifecycle::spawn_unchecked::{closure#1}::{closure_env#0}<test::run_test::{closure_env#1}, ()>>, ()> (panic.rs:359)
==302287==    by 0x15D021: {closure#1}<test::run_test::{closure_env#1}, ()> (lifecycle.rs:89)
==302287==    by 0x15D021: <std::thread::lifecycle::spawn_unchecked<test::run_test::{closure#1}, ()>::{closure#1} as core::ops::function::FnOnce<()>>::call_once::{shim:vtable#0} (function.rs:250)
==302287==    by 0x1F639E: call_once<(), (dyn core::ops::function::FnOnce<(), Output=()> + core::marker::Send), alloc::alloc::Global> (boxed.rs:2240)
==302287==    by 0x1F639E: <std::sys::thread::unix::Thread>::new::thread_start (unix.rs:118)
==302287==  Address 0x4bea038 is 152 bytes inside a block of size 232 free'd
==302287==    at 0x484988F: free (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==302287==    by 0x19AF8D: secp256k1_aggsig_context_destroy (main_impl.h:737)
==302287==    by 0x18CDBE: <secp256k1zkp::aggsig::AggSigContext as core::ops::drop::Drop>::drop (aggsig.rs:415)
==302287==    by 0x14CA5A: core::ptr::drop_in_place<secp256k1zkp::aggsig::AggSigContext> (mod.rs:805)
==302287==    by 0x14CB17: core::mem::drop (mod.rs:975)
==302287==    by 0x14D455: aggsig_double_free::aggsig_context_clone_double_free (aggsig_double_free.rs:15)
==302287==    by 0x14CEF6: aggsig_double_free::aggsig_context_clone_double_free::{{closure}} (aggsig_double_free.rs:9)
==302287==    by 0x14CA15: core::ops::function::FnOnce::call_once (function.rs:250)
==302287==    by 0x14DA2A: call_once<fn() -> core::result::Result<(), alloc::string::String>, ()> (function.rs:250)
==302287==    by 0x14DA2A: test::__rust_begin_short_backtrace::<core::result::Result<(), alloc::string::String>, fn() -> core::result::Result<(), alloc::string::String>> (lib.rs:663)
==302287==    by 0x15A41A: {closure#0} (lib.rs:686)
==302287==    by 0x15A41A: call_once<core::result::Result<(), alloc::string::String>, test::run_test_in_process::{closure_env#0}> (unwind_safe.rs:274)
==302287==    by 0x15A41A: do_call<core::panic::unwind_safe::AssertUnwindSafe<test::run_test_in_process::{closure_env#0}>, core::result::Result<(), alloc::string::String>> (panicking.rs:581)
==302287==    by 0x15A41A: catch_unwind<core::result::Result<(), alloc::string::String>, core::panic::unwind_safe::AssertUnwindSafe<test::run_test_in_process::{closure_env#0}>> (panicking.rs:544)
==302287==    by 0x15A41A: catch_unwind<core::panic::unwind_safe::AssertUnwindSafe<test::run_test_in_process::{closure_env#0}>, core::result::Result<(), alloc::string::String>> (panic.rs:359)
==302287==    by 0x15A41A: run_test_in_process (lib.rs:686)
==302287==    by 0x15A41A: test::run_test::{closure#0} (lib.rs:607)
==302287==    by 0x155B33: {closure#1} (lib.rs:637)
==302287==    by 0x155B33: std::sys::backtrace::__rust_begin_short_backtrace::<test::run_test::{closure#1}, ()> (backtrace.rs:166)
==302287==    by 0x15D021: {closure#0}<test::run_test::{closure_env#1}, ()> (lifecycle.rs:91)
==302287==    by 0x15D021: call_once<(), std::thread::lifecycle::spawn_unchecked::{closure#1}::{closure_env#0}<test::run_test::{closure_env#1}, ()>> (unwind_safe.rs:274)
==302287==    by 0x15D021: do_call<core::panic::unwind_safe::AssertUnwindSafe<std::thread::lifecycle::spawn_unchecked::{closure#1}::{closure_env#0}<test::run_test::{closure_env#1}, ()>>, ()> (panicking.rs:581)
==302287==    by 0x15D021: catch_unwind<(), core::panic::unwind_safe::AssertUnwindSafe<std::thread::lifecycle::spawn_unchecked::{closure#1}::{closure_env#0}<test::run_test::{closure_env#1}, ()>>> (panicking.rs:544)
==302287==    by 0x15D021: catch_unwind<core::panic::unwind_safe::AssertUnwindSafe<std::thread::lifecycle::spawn_unchecked::{closure#1}::{closure_env#0}<test::run_test::{closure_env#1}, ()>>, ()> (panic.rs:359)
==302287==    by 0x15D021: {closure#1}<test::run_test::{closure_env#1}, ()> (lifecycle.rs:89)
==302287==    by 0x15D021: <std::thread::lifecycle::spawn_unchecked<test::run_test::{closure#1}, ()>::{closure#1} as core::ops::function::FnOnce<()>>::call_once::{shim:vtable#0} (function.rs:250)
==302287==  Block was alloc'd at
==302287==    at 0x4846828: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
```

## Fix:
- Remove  `#[derive(Clone)]` from `AggSigContext` type.
- From my understanding `AggSigContext` wouldn't need to be shared across multiple owners, although if I am mistaken maybe you would want an overridden `Clone` implementation which increments a reference counter.